### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/common/file_utils.py
+++ b/common/file_utils.py
@@ -118,7 +118,10 @@ def get_file(fname, origin, unpack=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        parsed_url = urlparse(origin)
+        host = parsed_url.hostname
+        if host and (host == "modac.cancer.gov" or host.endswith(".modac.cancer.gov")):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Unified-Drug-Response-Predictor/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Unified-Drug-Response-Predictor/security/code-scanning/1)

To fix the issue, we need to replace the unsafe substring check with a proper domain validation mechanism. The best approach is to parse the `origin` URL using `urllib.parse` and extract its hostname. Then, we can verify that the hostname matches the expected domain (`modac.cancer.gov`) or is a subdomain of it. This ensures that only URLs pointing to the intended domain or its subdomains are accepted.

The changes will involve:
1. Importing `urlparse` from `urllib.parse`.
2. Parsing the `origin` URL to extract its hostname.
3. Replacing the substring check with a proper hostname validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
